### PR TITLE
Update COVID Publications menu text

### DIFF
--- a/backend/templates/cic_header.html
+++ b/backend/templates/cic_header.html
@@ -78,7 +78,7 @@
                       <a href="https://covidinfocommons.datascience.columbia.edu/content/groups-and-guides">Groups and Guides</a>
                     </li>
                     <li class="menu-item">
-                      <a href="https://covidinfocommons.datascience.columbia.edu/content/news-and-publications">COVID News and Publications</a>
+                      <a href="https://covidinfocommons.datascience.columbia.edu/content/news-and-publications">COVID Publications</a>
                     </li>
                     <li class="menu-item">
                       <a href="https://covidinfocommons.datascience.columbia.edu/content/2023-cic-student-paper-challenge">CIC Student Paper Challenge</a>


### PR DESCRIPTION
- Added support for partial keyword search.
- Change highlight color to yellow background
- Added extra client side logging for debugging the lag on the search website
- Updated menu text to "COVID Publications" 