### PR TITLE
Allow more than 10k results to be reported

### DIFF
--- a/backend/search/views.py
+++ b/backend/search/views.py
@@ -15,7 +15,7 @@ def get_facet_by_field(request) :
         verify_certs = True,
     )
 
-    query = {
+    query = {        
         "size": 0,
         "aggs" : {
             "patterns" : {
@@ -447,6 +447,8 @@ def search_datasets(request):
     )
 
     query = {
+        # must explicitly set track_total_hits, otherwise it defaults to 10,000
+        'track_total_hits': True,
         'query': {
             'match_all': {}
         }
@@ -467,6 +469,8 @@ def search_assets(request):
         verify_certs = True,
     )
     query = {
+        # must explicitly set track_total_hits, otherwise it defaults to 10,000
+        'track_total_hits': True,
         'query': {
             'match_all': {}
         }


### PR DESCRIPTION
ElasticSearch 7 introduced a default of 10,000 results reported for any query. 
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html#track-total-hits-10000-default

We need to override this to allow reporting of the correct number of results.